### PR TITLE
add --hideLocal options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Install the command line tool globally by running:
     --dev                Show development dependencies
     --peer               Show peer dependencies
     --update             Update the package.json file with remote version numbers
+    --hideLocal          Hide dependencies which local copy same as requested version
     --output [type]      Specify the output type [table,json]
     --outputFile <file>  the file to write data to
     --file <file>        The location of the package.json file

--- a/lib/npm-dview.js
+++ b/lib/npm-dview.js
@@ -251,26 +251,13 @@ getDependencies = function (dependencyKey, isEnabled, callback) {
 			//console.log(deps[depKey], defaultVersion)
 			if (deps.hasOwnProperty(depKey)) {
 				dep = deps[depKey];
-				if (program.hideLocal){
-					var depTrim = dep.replace(/[~^*]/gi, '');
-					if (depTrim !== defaultVersion){
-							results.push({
-							moduleName : depKey,
-							requestedVersion : depTrim,
-							localVersion : defaultVersion,
-							remoteVersion : defaultVersion,
-							requestedPrefix: dep.trim().match(/^(\~|\^|\>\=|\>|\=)*(.*)/)[1] || ''
-						});
-					}
-				} else {
-					results.push({
-						moduleName : depKey,
-						requestedVersion : dep,
-						localVersion : defaultVersion,
-						remoteVersion : defaultVersion,
-						requestedPrefix: dep.trim().match(/^(\~|\^|\>\=|\>|\=)*(.*)/)[1] || ''
-					});
-				}
+				results.push({
+					moduleName : depKey,
+					requestedVersion : dep,
+					localVersion : defaultVersion,
+					remoteVersion : defaultVersion,
+					requestedPrefix: dep.trim().match(/^(\~|\^|\>\=|\>|\=)*(.*)/)[1] || ''
+				});
 			}
 		}
 		bar = new ProgressBar('Processing: ' + dependencyKey + ' :current of :total [:bar] :percent :elapseds', {

--- a/lib/npm-dview.js
+++ b/lib/npm-dview.js
@@ -41,6 +41,7 @@ program
 	.option('--dev', 'Show development dependencies')
 	.option('--peer', 'Show peer dependencies')
 	.option('--update', 'Update the package.json file with remote version numbers')
+	.option('--hideLocal', 'Hide dependencies which local copy same as requestedVersion')
 	.option('--excludeCurrent', 'Exclude up-to-date packages from the output')
 	.option('--output [type]', 'Specify the output type [table,json]', 'table')
 	.option('--outputFile <file>', 'the file to write data to')
@@ -170,9 +171,37 @@ getOutputTable = function (key, items) {
 			head: ['Module Name', 'Requested', 'Local', 'Remote', 'Current?'],
 			colWidths: [27, 18, 8, 8, 10]
 		});
-	if (items.length > 0) {
-		for (i = 0; i < items.length; i++) {
-			item = items[i];
+
+	var oldItems = items.map(function(e){
+		return e;
+	});
+
+	var flag = items.map(function(e){
+		if (!!e.requestedVersion) {
+			return (e.requestedVersion).replace(/[<>=~^]/gi, '');
+		}
+	});
+	var newItems = [];
+	if (program.hideLocal){
+		oldItems.forEach(function(e, i){
+			if (flag[i] !== e.localVersion && ~i) {
+	            if (e.requestedPrefix.match(/[<>=~^]/gi, '')) {
+	                e.requestedVersion = e.requestedPrefix + e.requestedVersion;
+	            }
+				newItems.push(e);
+			} else {
+				if(!flag[i]){
+					newItems.push({noKey: 'noKey'});
+				}
+			}
+		});
+	} else {
+		newItems = oldItems;
+	}
+
+	if (newItems.length > 0) {
+		for (i = 0; i < newItems.length; i++) {
+			item = newItems[i];
 			if (item.hasOwnProperty('noKey')) {
 				table = new Table({
 					head: ['Warning']
@@ -216,16 +245,32 @@ getDependencies = function (dependencyKey, isEnabled, callback) {
 		callback(null, []);
 	} else {
 		deps = packageInfo[dependencyKey];
+		//var depTrimTest = deps
+		//console.log(depTrimTest)
 		for (depKey in deps) {
+			//console.log(deps[depKey], defaultVersion)
 			if (deps.hasOwnProperty(depKey)) {
 				dep = deps[depKey];
-				results.push({
-					moduleName : depKey,
-					requestedVersion : dep,
-					localVersion : defaultVersion,
-					remoteVersion : defaultVersion,
-					requestedPrefix: dep.trim().match(/^(\~|\^|\>\=|\>|\=)*(.*)/)[1] || ''
-				});
+				if (program.hideLocal){
+					var depTrim = dep.replace(/[~^*]/gi, '');
+					if (depTrim !== defaultVersion){
+							results.push({
+							moduleName : depKey,
+							requestedVersion : depTrim,
+							localVersion : defaultVersion,
+							remoteVersion : defaultVersion,
+							requestedPrefix: dep.trim().match(/^(\~|\^|\>\=|\>|\=)*(.*)/)[1] || ''
+						});
+					}
+				} else {
+					results.push({
+						moduleName : depKey,
+						requestedVersion : dep,
+						localVersion : defaultVersion,
+						remoteVersion : defaultVersion,
+						requestedPrefix: dep.trim().match(/^(\~|\^|\>\=|\>|\=)*(.*)/)[1] || ''
+					});
+				}
 			}
 		}
 		bar = new ProgressBar('Processing: ' + dependencyKey + ' :current of :total [:bar] :percent :elapseds', {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "npm-dview",
   "description": "Compare current package.json dependency version numbers with latest remote version number.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "http://skratchdot.com/projects/npm-dview",
   "preferGlobal": true,
   "main": "./lib/npm-dview.js",

--- a/test/npm-dview_test.js
+++ b/test/npm-dview_test.js
@@ -76,6 +76,15 @@ exports['npm-dview tests'] = {
 			test.done();
 		});
 	},
+	'npm-dview --hideLocal': function (test) {
+		exec(execPrefix + '--hideLocal', function (error, stdout, stderr) {
+			var res = stdout.match(regexHeaderNotFound) || [];
+			test.expect(2);
+			test.equal(res.length, 1, 'should show 1 table');
+			test.equal(stderr, '', 'should be an empty string');
+			test.done();
+		});
+	},
 	'npm-dview --file': function (test) {
 		exec(execPrefix + '--file', function (error, stdout, stderr) {
 			test.expect(1);


### PR DESCRIPTION
Hello @skratchdot, great tools!, which I use very often. Btw I add new options which allow to hide local dep if it has same version as requested, it's limited to proceeding's symbols `<>=~^`. Test build on my fork succeeded [![Build Status](https://travis-ci.org/syarul/npm-dview.svg?branch=master)](https://travis-ci.org/syarul/npm-dview)
